### PR TITLE
Add send command to pb_cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ pb_cli modify delete logs -f "created < '2023-01-01'" --dry-run
 
 # Create a new record
 pb_cli create users -d '{"name": "John Doe", "email": "john@example.com"}'
+
+# Send a custom request
+pb_cli send POST http://localhost:8090/api/endpoint -h '{"Content-Type": "application/json"}' -d '{"key": "value"}'
 ```
 
 ## Features
@@ -40,6 +43,7 @@ pb_cli create users -d '{"name": "John Doe", "email": "john@example.com"}'
 - List Records: Query and display records from any collection
 - Modify Records: Update or delete records in bulk with filters
 - Create Records: Add new records to any collection
+- Send Custom Requests: Make custom requests with method, custom header (including token), and custom data
 - Dry Run: Preview changes before applying them
 
 ## Commands
@@ -71,6 +75,11 @@ pb_cli create users -d '{"name": "John Doe", "email": "john@example.com"}'
 ### Create Records
 - `create <collection> [options]`: Create a new record
   - `-d, --data <json>`: JSON data for the new record
+
+### Send Custom Requests
+- `send <method> <url> [options]`: Send a custom request
+  - `-h, --headers <headers>`: Custom headers as JSON string
+  - `-d, --data <data>`: Request data as JSON string
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -26,14 +26,16 @@
   "author": "Abdramane Sakone",
   "license": "MIT",
   "dependencies": {
-    "pocketbase": "^0.20.1",
     "commander": "^11.1.0",
-    "dotenv": "^16.3.1"
+    "dotenv": "^16.3.1",
+    "node-fetch": "^3.3.2",
+    "pocketbase": "^0.20.1"
   },
   "devDependencies": {
     "@types/node": "^20.10.4",
-    "typescript": "^5.3.3",
-    "ts-node": "^10.9.1"
+    "@types/node-fetch": "^2.6.12",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.3.3"
   },
   "engines": {
     "node": ">=18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       dotenv:
         specifier: ^16.3.1
         version: 16.4.7
+      node-fetch:
+        specifier: ^3.3.2
+        version: 3.3.2
       pocketbase:
         specifier: ^0.20.1
         version: 0.20.3
@@ -21,6 +24,9 @@ importers:
       '@types/node':
         specifier: ^20.10.4
         version: 20.17.9
+      '@types/node-fetch':
+        specifier: ^2.6.12
+        version: 2.6.12
       ts-node:
         specifier: ^10.9.1
         version: 10.9.2(@types/node@20.17.9)(typescript@5.7.2)
@@ -56,6 +62,9 @@ packages:
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
+  '@types/node-fetch@2.6.12':
+    resolution: {integrity: sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==}
+
   '@types/node@20.17.9':
     resolution: {integrity: sha512-0JOXkRyLanfGPE2QRCwgxhzlBAvaRdCNMcvbd7jFfpmD4eEXll7LRwy5ymJmyeZqk7Nh7eD2LeUyQ68BbndmXw==}
 
@@ -71,12 +80,27 @@ packages:
   arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
@@ -86,8 +110,36 @@ packages:
     resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
     engines: {node: '>=12'}
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
+  form-data@4.0.1:
+    resolution: {integrity: sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==}
+    engines: {node: '>= 6'}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   pocketbase@0.20.3:
     resolution: {integrity: sha512-qembHhE7HumDBZpxWgFIbhJPeaCoUIdwhW59xF/VlMR79pDTYz/LaQ4q89y7GczKo4X9actFgFN8hs4dTl0spQ==}
@@ -117,6 +169,10 @@ packages:
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
   yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
     engines: {node: '>=6'}
@@ -144,6 +200,11 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
+  '@types/node-fetch@2.6.12':
+    dependencies:
+      '@types/node': 20.17.9
+      form-data: 4.0.1
+
   '@types/node@20.17.9':
     dependencies:
       undici-types: 6.19.8
@@ -156,15 +217,54 @@ snapshots:
 
   arg@4.1.3: {}
 
+  asynckit@0.4.0: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   commander@11.1.0: {}
 
   create-require@1.1.1: {}
+
+  data-uri-to-buffer@4.0.1: {}
+
+  delayed-stream@1.0.0: {}
 
   diff@4.0.2: {}
 
   dotenv@16.4.7: {}
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
+  form-data@4.0.1:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   make-error@1.3.6: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  node-domexception@1.0.0: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   pocketbase@0.20.3: {}
 
@@ -191,5 +291,7 @@ snapshots:
   undici-types@6.19.8: {}
 
   v8-compile-cache-lib@3.0.1: {}
+
+  web-streams-polyfill@3.3.3: {}
 
   yn@3.1.1: {}

--- a/src/commands/send.commands.ts
+++ b/src/commands/send.commands.ts
@@ -1,0 +1,49 @@
+import { Command } from 'commander';
+import { getActiveProfile, loadToken } from '../utils.js';
+import fetch from 'node-fetch';
+
+export function createSendCommand(): Command {
+    return new Command('send')
+        .description('Send a custom request with method, custom header (including token), and custom data')
+        .argument('<method>', 'HTTP method (GET, POST, PUT, DELETE, etc.)')
+        .argument('<url>', 'Request URL')
+        .option('-h, --headers <headers>', 'Custom headers as JSON string', '{}')
+        .option('-d, --data <data>', 'Request data as JSON string', '{}')
+        .action(async (method: string, url: string, options: any) => {
+            try {
+                const profile = getActiveProfile();
+                if (!profile) {
+                    console.error("No active profile. Please add a profile first with: profile add <name> <url> <email> <password>");
+                    process.exit(1);
+                }
+
+                const token = loadToken();
+                if (!token) {
+                    console.error("No token found. Please login first.");
+                    process.exit(1);
+                }
+
+                const headers = JSON.parse(options.headers);
+                headers['Authorization'] = `Bearer ${token}`;
+
+                const data = JSON.parse(options.data);
+
+                const response = await fetch(url, {
+                    method,
+                    headers,
+                    body: method !== 'GET' ? JSON.stringify(data) : undefined
+                });
+
+                const responseBody = await response.text();
+                console.log(`Response: ${response.status} ${response.statusText}`);
+                console.log(responseBody);
+            } catch (error) {
+                if (error instanceof SyntaxError) {
+                    console.error("Invalid JSON format. Please provide a valid JSON string.");
+                } else {
+                    console.error("Error sending request:", error);
+                }
+                process.exit(1);
+            }
+        });
+}

--- a/src/commands/send.commands.ts
+++ b/src/commands/send.commands.ts
@@ -1,0 +1,73 @@
+import { Command } from 'commander';
+import { getActiveProfile } from '../utils.js';
+import fetch from 'node-fetch';
+import { initPocketBase, ensureAuthenticated, pb } from '../services/pb.service.js';
+
+export function createSendCommand(): Command {
+    const cmd = new Command('send')
+        .description('Send HTTP requests to PocketBase with authentication')
+        .argument('<method>', 'HTTP method (GET, POST, PUT, DELETE, PATCH)')
+        .argument('<url>', 'Request URL path (e.g., /api/collections)')
+        .option('-h, --headers <headers>', 'Custom headers as JSON string', '{}')
+        .option('-d, --data <data>', 'Request body as JSON string', '{}')
+        .addHelpText('after', `
+Examples:
+  $ pb_cli send GET /api/health                    # Check API health
+  $ pb_cli send GET /api/collections               # List all collections
+  $ pb_cli send POST /api/collections -d '{"name": "posts"}'  # Create collection
+  $ pb_cli send GET /api/collections/posts/records # List records
+  $ pb_cli send DELETE /api/collections/posts      # Delete collection
+
+Arguments:
+  method   HTTP method (required)
+  url      Request URL path (required)
+
+Options:
+  -h, --headers <json>  Additional headers as JSON string
+  -d, --data <json>    Request body as JSON string
+        `)
+        .showHelpAfterError('Add --help for additional information');
+
+    cmd.action(async (method?: string, url?: string, options?: any) => {
+        if (!method || !url) {
+            cmd.help();
+            return;
+        }
+        try {
+            const profile = getActiveProfile();
+            if (!profile) {
+                console.error("No active profile. Please add a profile first with: profile add <name> <url> <email> <password>");
+                process.exit(1);
+            }
+
+            // Initialize PB and ensure we're authenticated
+            initPocketBase();
+            await ensureAuthenticated();
+
+            const headers = JSON.parse(options.headers);
+            headers['Authorization'] = pb.authStore.token;
+
+            const fullUrl = url.startsWith('http') ? url : `${profile.url}${url}`;
+            const data = JSON.parse(options.data);
+
+            const response = await fetch(fullUrl, {
+                method,
+                headers,
+                body: method !== 'GET' ? JSON.stringify(data) : undefined
+            });
+
+            const responseBody = await response.text();
+            console.log(`Response: ${response.status} ${response.statusText}`);
+            console.log(responseBody);
+        } catch (error) {
+            if (error instanceof SyntaxError) {
+                console.error("Invalid JSON format. Please provide a valid JSON string.");
+            } else {
+                console.error("Error sending request:", error);
+            }
+            process.exit(1);
+        }
+    });
+
+    return cmd;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { createListCommand } from "./commands/list.commands.js";
 import { createModifyCommand } from "./commands/modify.commands.js";
 import { adminLogin, initPocketBase } from "./services/pb.service.js";
 import { createCreateCommand } from "./commands/create.commands.js";
+import { createSendCommand } from "./commands/send.commands.js";
 
 dotenv.config();
 
@@ -22,6 +23,7 @@ program.addCommand(createProfileCommands());
 program.addCommand(createListCommand());
 program.addCommand(createModifyCommand());
 program.addCommand(createCreateCommand());
+program.addCommand(createSendCommand());
 
 // Add login command
 program


### PR DESCRIPTION
Add a new `send` command to `pb_cli` for making custom requests with method, custom header (including token), and custom data.

* **New Command**: Add `send` command in `src/commands/send.commands.ts` to handle custom requests.
  * Accept arguments for method, URL, headers, and data.
  * Automatically include the token from the active profile in the headers.
* **Index Update**: Update `src/index.ts` to include the new `send` command.
* **Documentation**: Update `README.md` to document the usage of the new `send` command.

